### PR TITLE
Added null logging handler to root logger (issue #19)

### DIFF
--- a/autoload/vimhdl.vim
+++ b/autoload/vimhdl.vim
@@ -30,6 +30,10 @@ python << EOF
 import sys, vim
 import os.path as p
 import logging
+
+# Add a null handler for issue #19
+logging.root.addHandler(logging.NullHandler())
+
 _logger = logging.getLogger(__name__)
 for path in (p.join(vim.eval('s:vimhdl_path'), 'python'),
              p.join(vim.eval('s:vimhdl_path'), 'dependencies', 'hdlcc')


### PR DESCRIPTION
At vimhdl initial setup, we'll add a null logging handler to avoid the "No handlers could be found for logger "vimhdl.vim_client" on stdout. This should fix #19.
