### PR TITLE
Merging Testing branch

### DIFF
--- a/.ci/vimhdl_tests/test_runner.py
+++ b/.ci/vimhdl_tests/test_runner.py
@@ -110,108 +110,103 @@ with such.A('vim-hdl test') as it:
         cleanHdlLib()
         pipUninstallHdlcc()
 
-    with it.having("a session with multiple files to edit"):
-        @it.should("pass")
-        def test(case):
-            vroom_test = p.join(_PATH_TO_TESTS,
-                                "test_001_editing_multiple_files.vroom")
-            try:
-                subp.check_call(getTestCommand(vroom_test))
-            except subp.CalledProcessError:
-                _logger.exception("Excepion caught while testing")
-                it.fail("Test failed: %s" % case)
+    @it.should("handle session with multiple files to edit")
+    def test(case):
+        vroom_test = p.join(_PATH_TO_TESTS,
+                            "test_001_editing_multiple_files.vroom")
+        try:
+            subp.check_call(getTestCommand(vroom_test))
+        except subp.CalledProcessError:
+            _logger.exception("Excepion caught while testing")
+            it.fail("Test failed: %s" % case)
 
-    with it.having("no project configured"):
-        @it.should("pass")
-        def test(case):
-            vroom_test = p.join(_PATH_TO_TESTS,
-                                'test_002_no_project_configured.vroom')
-            try:
-                subp.check_call(getTestCommand(vroom_test))
-            except subp.CalledProcessError:
-                _logger.exception("Excepion caught while testing")
-                it.fail("Test failed: %s" % case)
+    @it.should("run only static checks if no project was configured")
+    def test(case):
+        vroom_test = p.join(_PATH_TO_TESTS,
+                            'test_002_no_project_configured.vroom')
+        try:
+            subp.check_call(getTestCommand(vroom_test))
+        except subp.CalledProcessError:
+            _logger.exception("Excepion caught while testing")
+            it.fail("Test failed: %s" % case)
 
-    with it.having("a project file but no builder working"):
-        @it.should("pass")
-        def test(case):
-            vroom_test = p.join(_PATH_TO_TESTS,
-                                'test_003_with_project_without_builder.vroom')
-            try:
-                subp.check_call(getTestCommand(vroom_test))
-            except subp.CalledProcessError:
-                _logger.exception("Excepion caught while testing")
-                it.fail("Test failed: %s" % case)
+    @it.should("warn when unable to create the configured builder")
+    def test(case):
+        gitClean('../hdlcc_ci/hdl_lib')
+        vroom_test = p.join(_PATH_TO_TESTS,
+                            'test_003_with_project_without_builder.vroom')
+        try:
+            subp.check_call(getTestCommand(vroom_test))
+        except subp.CalledProcessError:
+            _logger.exception("Excepion caught while testing")
+            it.fail("Test failed: %s" % case)
 
-    with it.having("built project with hdlcc standalone before editing"):
-        @it.should("pass")
-        def test(case):
-            vroom_test = p.join(_PATH_TO_TESTS, 'test_004_issue_10.vroom')
-            cmd = ['hdlcc', HDLCC_CI + '/hdl_lib/ghdl.prj', '-cb', '-vvv']
+    @it.should("allow building via hdlcc standalone before editing")
+    def test(case):
+        vroom_test = p.join(_PATH_TO_TESTS, 'test_004_issue_10.vroom')
+        cmd = ['hdlcc', HDLCC_CI + '/hdl_lib/ghdl.prj', '-cb', '-vvv']
 
-            _logger.info(cmd)
-            exc = None
-            try:
-                output = subp.check_output(cmd).splitlines()
-            except subp.CalledProcessError as exc:
-                _logger.exception("Excepion caught while testing")
-                output = list(exc.output.splitlines())
+        _logger.info(cmd)
+        exc = None
+        try:
+            output = subp.check_output(cmd).splitlines()
+        except subp.CalledProcessError as exc:
+            _logger.exception("Excepion caught while testing")
+            output = list(exc.output.splitlines())
 
-            if exc is None:
-                for line in output:
-                    _logger.info("> " + line)
-            else:
-                for line in output:
-                    _logger.warning("> " + line)
+        if exc is None:
+            for line in output:
+                _logger.info("> " + line)
+        else:
+            for line in output:
+                _logger.warning("> " + line)
 
-            try:
-                subp.check_call(getTestCommand(vroom_test))
-            except subp.CalledProcessError:
-                _logger.exception("Excepion caught while testing")
-                it.fail("Test failed: %s" % case)
+        try:
+            subp.check_call(getTestCommand(vroom_test))
+        except subp.CalledProcessError:
+            _logger.exception("Excepion caught while testing")
+            it.fail("Test failed: %s" % case)
 
-    with it.having("test for issue 15 -- jumping from quickfix"):
-        @it.should("not result on E926")
-        def test(case):
-            if p.exists('source.vhd'):
-                os.remove('source.vhd')
+    @it.should("not result on E926 when jumping from quickfix")
+    def test(case):
+        if p.exists('source.vhd'):
+            os.remove('source.vhd')
 
-            vroom_test = p.join(_PATH_TO_TESTS,
-                                'test_005_issue_15_quickfix_jump.vroom')
-            try:
-                subp.check_call(getTestCommand(vroom_test))
-            except subp.CalledProcessError:
-                it.fail("Test failed: %s" % case)
+        vroom_test = p.join(_PATH_TO_TESTS,
+                            'test_005_issue_15_quickfix_jump.vroom')
+        try:
+            subp.check_call(getTestCommand(vroom_test))
+        except subp.CalledProcessError:
+            it.fail("Test failed: %s" % case)
 
-    with it.having("any VHDL file"):
-        @it.should("print vimhdl info")
-        def test(case):
-            import sys
-            sys.path.insert(0, 'python')
-            sys.path.insert(0, p.join('dependencies', 'hdlcc'))
-            import vimhdl
-            import hdlcc
+    @it.should("print vimhdl diagnose info")
+    def test(case):
+        import sys
+        sys.path.insert(0, 'python')
+        sys.path.insert(0, p.join('dependencies', 'hdlcc'))
+        import vimhdl
+        import hdlcc
 
-            vroom_test = p.join(_PATH_TO_TESTS,
-                                'test_006_get_vim_info.vroom')
-            lines = open(vroom_test, 'r').read()
+        vroom_test = p.join(_PATH_TO_TESTS,
+                            'test_006_get_vim_info.vroom')
+        lines = open(vroom_test, 'r').read()
 
-            lines = lines.replace("__vimhdl__version__", vimhdl.__version__)
-            lines = lines.replace("__hdlcc__version__", hdlcc.__version__)
-            sys.path.remove('python')
-            sys.path.remove(p.join('dependencies', 'hdlcc'))
+        lines = lines.replace("__vimhdl__version__", vimhdl.__version__)
+        lines = lines.replace("__hdlcc__version__", hdlcc.__version__)
+        sys.path.remove('python')
+        sys.path.remove(p.join('dependencies', 'hdlcc'))
 
-            del sys.modules['vimhdl']
-            del sys.modules['hdlcc']
+        del sys.modules['vimhdl']
+        del sys.modules['hdlcc']
 
-            vroom_post = vroom_test.replace('test_006', 'alt_test_006')
-            open(vroom_post, 'w').write(lines)
+        vroom_post = vroom_test.replace('test_006', 'alt_test_006')
+        open(vroom_post, 'w').write(lines)
 
-            try:
-                subp.check_call(getTestCommand(vroom_post))
-            except subp.CalledProcessError:
-                _logger.exception("Excepion caught while testing")
-                it.fail("Test failed: %s" % case)
+        try:
+            subp.check_call(getTestCommand(vroom_post))
+        except subp.CalledProcessError:
+            _logger.exception("Excepion caught while testing")
+            it.fail("Test failed: %s" % case)
 
     @it.should("only start hdlcc server when opening a hdl file")
     @params('vhdl', 'verilog', 'systemverilog')

--- a/.ci/vimhdl_tests/test_vim_helpers.py
+++ b/.ci/vimhdl_tests/test_vim_helpers.py
@@ -27,18 +27,20 @@ _CI = os.environ.get("CI", None) is not None
 _logger = logging.getLogger(__name__)
 
 def _setupPaths():
-    path_to_vimhdl = p.abspath(p.join(p.dirname(__file__), '..', '..', 'python'))
-    print path_to_vimhdl
-    sys.path.insert(0, path_to_vimhdl)
+    base_path = p.abspath(p.join(p.dirname(__file__), '..', '..'))
+    for path in (p.join(base_path, 'python'),
+                 p.join(base_path, 'dependencies', 'requests')):
+        print path
+        sys.path.insert(0, path)
 
 _setupPaths()
 
-from vim_mock import mockVim
+# pylint: disable=import-error,wrong-import-position
+from vimhdl_tests.vim_mock import mockVim
 mockVim()
-
 import vim
-
 import vimhdl.vim_helpers as vim_helpers
+# pylint: enable=import-error,wrong-import-position
 
 with such.A('vim_helpers module') as it:
     @it.should("return all buffer variables from the current buffer if "

--- a/.ci/vroom/test_006_get_vim_info.vroom
+++ b/.ci/vroom/test_006_get_vim_info.vroom
@@ -6,4 +6,5 @@ __hdlcc__version__ with their real values
   ~ vimhdl debug info
   ~ - vimhdl version: __vimhdl__version__
   ~ - hdlcc version: __hdlcc__version__
+  ~ - Server PID: .* (regex)
 

--- a/.ci/vroom/test_007_server_should_start_only_when_opening_hdl_file.vroom
+++ b/.ci/vroom/test_007_server_should_start_only_when_opening_hdl_file.vroom
@@ -1,0 +1,14 @@
+Right after opening Vim, the hdlcc server should not be running. We'll call 
+VimhdlInfo twice to ensure it doesn't starts
+  :VimhdlInfo
+  ~ vimhdl debug info
+  ~ - vimhdl version: .* (regex)
+  ~ - hdlcc server is not running
+Setting the filetype to __filetype__ should trigger the server start
+  :set filetype=__filetype__
+Now the server should be running
+  :VimhdlInfo
+  ~ vimhdl debug info
+  ~ - vimhdl version: __vimhdl__version__
+  ~ - hdlcc version: __hdlcc__version__
+  ~ - Server PID: .* (regex)

--- a/README.md
+++ b/README.md
@@ -3,6 +3,7 @@
 [![Build Status](https://travis-ci.org/suoto/vim-hdl.svg?branch=master)](https://travis-ci.org/suoto/vim-hdl)
 [![Coverage Status](https://coveralls.io/repos/github/suoto/vim-hdl/badge.svg?branch=master)](https://coveralls.io/github/suoto/vim-hdl?branch=master)
 [![Code Health](https://landscape.io/github/suoto/vim-hdl/master/landscape.svg?style=flat)](https://landscape.io/github/suoto/vim-hdl/master)
+[![Join the chat at https://gitter.im/suoto/vim-hdl](https://badges.gitter.im/suoto/vim-hdl.svg)](https://gitter.im/suoto/vim-hdl?utm_source=badge&utm_medium=badge&utm_campaign=pr-badge&utm_content=badge)
 [![Analytics](https://ga-beacon.appspot.com/UA-68153177-3/vim-hdl/README.md?pixel)](https://github.com/suoto/vim-hdl)
 
 vim-hdl is a Vim plugin that uses [`hdlcc`][hdlcc] to provide some helpers to

--- a/autoload/vimhdl.vim
+++ b/autoload/vimhdl.vim
@@ -24,6 +24,7 @@ function! vimhdl#setupPython()
 python << EOF
 try:
     vimhdl_client
+    _logger = logging.getLogger(__name__)
     _logger.warning("vimhdl client already exists, skiping")
 except NameError:
     import sys, vim
@@ -36,8 +37,7 @@ except NameError:
     _logger = logging.getLogger(__name__)
     for path in (p.join(vim.eval('s:vimhdl_path'), 'python'),
                  p.join(vim.eval('s:vimhdl_path'), 'dependencies', 'requests'),
-                 p.join(vim.eval('s:vimhdl_path'), 'dependencies', 'hdlcc')
-             ):
+                 p.join(vim.eval('s:vimhdl_path'), 'dependencies', 'hdlcc')):
         if path not in sys.path:
             path = p.abspath(path)
             if p.exists(path):
@@ -69,16 +69,15 @@ endfunction
 " { vimhdl#setupHooks()
 " ============================================================================
 " Setup Vim's Python environment to call vim-hdl within Vim
-function! vimhdl#setupHooks()
-    autocmd! BufWritePost *.vhd :py vimhdl_client.requestUiMessages('BufWritePost')
-    autocmd! BufEnter     *.vhd :py vimhdl_client.requestUiMessages('BufEnter')
-    autocmd! BufLeave     *.vhd :py vimhdl_client.requestUiMessages('BufLeave')
-    autocmd! FocusGained  *.vhd :py vimhdl_client.requestUiMessages('FocusGained')
-    autocmd! CursorMoved  *.vhd :py vimhdl_client.requestUiMessages('CursorMoved')
-    autocmd! CursorMovedI *.vhd :py vimhdl_client.requestUiMessages('CursorMovedI')
-    autocmd! CursorHold   *.vhd :py vimhdl_client.requestUiMessages('CursorHold')
-    autocmd! CursorHoldI  *.vhd :py vimhdl_client.requestUiMessages('CursorHoldI')
-    autocmd! InsertLeave  *.vhd :py vimhdl_client.requestUiMessages('InsertLeave')
+function! vimhdl#setupHooks(...)
+    for ext in a:000
+        for event in ['BufWritePost', 'BufEnter', 'BufLeave', 'FocusGained', 
+                     \'CursorMoved', 'CursorMovedI', 'CursorHold', 'CursorHoldI',
+                     \'InsertLeave']
+            execute("autocmd! " . event . " " . ext . " " . 
+                   \":py vimhdl_client.requestUiMessages('" . event . "')")
+        endfor
+    endfor
 endfunction
 " }
 " { vimhdl#setup()
@@ -87,13 +86,13 @@ endfunction
 function! vimhdl#setup()
     if exists('g:vimhdl_loaded') && g:vimhdl_loaded 
         return
-    endif
+    endi
 
     let g:vimhdl_loaded = 1
 
     call vimhdl#setupPython()
     call vimhdl#setupCommands()
-    call vimhdl#setupHooks()
+    call vimhdl#setupHooks('*.vhd', '*.v', '*.sv')
 
 endfunction
 " }

--- a/autoload/vimhdl.vim
+++ b/autoload/vimhdl.vim
@@ -1,5 +1,7 @@
 " This file is part of vim-hdl.
 "
+" Copyright (c) 2015-2016 Andre Souto
+"
 " vim-hdl is free software: you can redistribute it and/or modify
 " it under the terms of the GNU General Public License as published by
 " the Free Software Foundation, either version 3 of the License, or

--- a/autoload/vimhdl.vim
+++ b/autoload/vimhdl.vim
@@ -127,7 +127,7 @@ python << EOF
 _logger.info("Restarting hdlcc server")
 vimhdl_client.shutdown()
 del vimhdl_client
-vimhdl_client = vimhdl.VimhdlClient()
+vimhdl_client = vimhdl.VimhdlClient(log_level='WARNING')
 vimhdl_client.startServer()
 _logger.info("hdlcc restart done")
 EOF

--- a/ftplugin/vhdl.vim
+++ b/ftplugin/vhdl.vim
@@ -1,5 +1,7 @@
 " This file is part of vim-hdl.
 "
+" Copyright (c) 2015-2016 Andre Souto
+"
 " vim-hdl is free software: you can redistribute it and/or modify
 " it under the terms of the GNU General Public License as published by
 " the Free Software Foundation, either version 3 of the License, or

--- a/plugin/vimhdl.vim
+++ b/plugin/vimhdl.vim
@@ -15,8 +15,9 @@
 " You should have received a copy of the GNU General Public License
 " along with vim-hdl.  If not, see <http://www.gnu.org/licenses/>.
 "
-autocmd! BufEnter * :call vimhdl#setup()
-autocmd! BufEnter * :call vimhdl#setup()
-autocmd! BufEnter * :call vimhdl#setup()
+autocmd! BufEnter *             :call vimhdl#setup()
+autocmd! Filetype vhdl          :call vimhdl#setup()
+autocmd! Filetype verilog       :call vimhdl#setup()
+autocmd! Filetype systemverilog :call vimhdl#setup()
 
 " vim: set foldmarker={,} foldlevel=0 foldmethod=marker :

--- a/plugin/vimhdl.vim
+++ b/plugin/vimhdl.vim
@@ -15,7 +15,8 @@
 " You should have received a copy of the GNU General Public License
 " along with vim-hdl.  If not, see <http://www.gnu.org/licenses/>.
 "
-
-call vimhdl#setup()
+autocmd! BufEnter * :call vimhdl#setup()
+autocmd! BufEnter * :call vimhdl#setup()
+autocmd! BufEnter * :call vimhdl#setup()
 
 " vim: set foldmarker={,} foldlevel=0 foldmethod=marker :

--- a/python/vimhdl/__init__.py
+++ b/python/vimhdl/__init__.py
@@ -1,5 +1,7 @@
 # This file is part of vim-hdl.
 #
+# Copyright (c) 2015-2016 Andre Souto
+#
 # vim-hdl is free software: you can redistribute it and/or modify
 # it under the terms of the GNU General Public License as published by
 # the Free Software Foundation, either version 3 of the License, or

--- a/python/vimhdl/base_requests.py
+++ b/python/vimhdl/base_requests.py
@@ -1,5 +1,7 @@
 # This file is part of vim-hdl.
 #
+# Copyright (c) 2015-2016 Andre Souto
+#
 # vim-hdl is free software: you can redistribute it and/or modify
 # it under the terms of the GNU General Public License as published by
 # the Free Software Foundation, either version 3 of the License, or

--- a/python/vimhdl/vim_client.py
+++ b/python/vimhdl/vim_client.py
@@ -55,10 +55,8 @@ class VimhdlClient(object):
         self._server = None
         self._host = options.get('host', 'localhost')
         self._port = options.get('port', vim_helpers.getUnusedLocalhostPort())
-        self._server_args = [
-            '--log-level', str(options.get('log_level', 'DEBUG')),
-            '--log-stream', options.get('log_target', '/tmp/hdlcc.log')
-        ]
+        self._log_level = str(options.get('log_level', 'DEBUG'))
+        self._log_stream = options.get('log_target', '/tmp/hdlcc.log')
 
         self._posted_notifications = []
 
@@ -101,15 +99,16 @@ class VimhdlClient(object):
         vimhdl_path = p.abspath(p.join(p.dirname(__file__), '..', '..'))
 
         hdlcc_server = p.join(vimhdl_path, 'dependencies', 'hdlcc', 'hdlcc',
-                              'code_checker_server.py')
+                              'hdlcc_server.py')
 
         cmd = [hdlcc_server,
                '--host', self._host,
                '--port', str(self._port),
                '--stdout', '/tmp/hdlcc-stdout.log',
                '--stderr', '/tmp/hdlcc-stderr.log',
-               '--attach-to-pid', str(os.getpid())] + \
-                self._server_args
+               '--attach-to-pid', str(os.getpid()),
+               '--log-level', self._log_level,
+               '--log-stream', self._log_stream]
 
         self._logger.info("Starting hdlcc server with '%s'", " ".join(cmd))
 

--- a/python/vimhdl/vim_client.py
+++ b/python/vimhdl/vim_client.py
@@ -61,8 +61,8 @@ class VimhdlClient(object):
 
         self._ui_queue = Queue()
 
-        self._setup()
-        self._waitForServerSetup()
+        self.startServer()
+        self.waitForServerSetup()
 
         import atexit
         atexit.register(self.shutdown)
@@ -86,8 +86,8 @@ class VimhdlClient(object):
             self._postWarning("hdlcc server is not running")
         return is_alive
 
-    def _setup(self):
-        "Launches the hdlcc server"
+    def startServer(self):
+        "Starts the hdlcc server"
         self._logger.info("Running vim_hdl client setup")
 
         vimhdl_path = p.abspath(p.join(p.dirname(__file__), '..', '..'))
@@ -112,7 +112,7 @@ class VimhdlClient(object):
         except subp.CalledProcessError:
             self._logger.exception("Error calling '%s'", " ".join(cmd))
 
-    def _waitForServerSetup(self):
+    def waitForServerSetup(self):
         "Wait for ~10s until the server is actually responding"
         for _ in range(10):
             time.sleep(0.1)
@@ -133,6 +133,7 @@ class VimhdlClient(object):
             self._logger.warning("Server is not running")
             return
         self._logger.debug("Sending shutdown signal")
+        os.kill(self._server.pid, 9)
         self._server.terminate()
         self._logger.debug("Done")
 

--- a/python/vimhdl/vim_client.py
+++ b/python/vimhdl/vim_client.py
@@ -1,5 +1,7 @@
 # This file is part of vim-hdl.
 #
+# Copyright (c) 2015-2016 Andre Souto
+#
 # vim-hdl is free software: you can redistribute it and/or modify
 # it under the terms of the GNU General Public License as published by
 # the Free Software Foundation, either version 3 of the License, or

--- a/python/vimhdl/vim_client.py
+++ b/python/vimhdl/vim_client.py
@@ -81,10 +81,10 @@ class VimhdlClient(object):
 
     def _isServerAlive(self):
         "Checks if the the server is alive"
-        sts = self._server.poll() is None
-        if not sts:
+        is_alive = self._server.poll() is None
+        if not is_alive:
             self._postWarning("hdlcc server is not running")
-        return sts
+        return is_alive
 
     def _setup(self):
         "Launches the hdlcc server"
@@ -161,6 +161,7 @@ class VimhdlClient(object):
         """Returns a list (vim.List) of messages (vim.Dictionary) to
         populate the quickfix list. For more info, check :help getqflist()"""
         if not self._isServerAlive():
+            self._logger.warning("Server is not alive, can't get messages")
             return
 
         if vim_buffer is None:

--- a/python/vimhdl/vim_client.py
+++ b/python/vimhdl/vim_client.py
@@ -231,9 +231,10 @@ class VimhdlClient(object):
         if response is None:
             return "hdlcc server is not running"
 
+        self._logger.info("Response: %s", str(response.json()['info']))
+
         return "\n".join(["vimhdl version: " + vimhdl.__version__] +
-                         ["%s: %s" % (k, v)
-                          for k, v in response.json().items()])
+                         response.json()['info'])
 
     def rebuildProject(self):
         "Rebuilds the current project"

--- a/python/vimhdl/vim_helpers.py
+++ b/python/vimhdl/vim_helpers.py
@@ -1,5 +1,7 @@
 # This file is part of vim-hdl.
 #
+# Copyright (c) 2015-2016 Andre Souto
+#
 # vim-hdl is free software: you can redistribute it and/or modify
 # it under the terms of the GNU General Public License as published by
 # the Free Software Foundation, either version 3 of the License, or

--- a/run_tests.sh
+++ b/run_tests.sh
@@ -43,7 +43,6 @@ if [ -z "${CI}" ]; then
   . ${VIRTUAL_ENV_DEST}/bin/activate
 
   pip install git+https://github.com/suoto/rainbow_logging_handler
-  pip install -r requirements.txt
 fi
 
 if [ -n "${CLEAN_AND_QUIT}${CLEAN}" ]; then

--- a/run_tests.sh
+++ b/run_tests.sh
@@ -1,6 +1,8 @@
 #!/usr/bin/env bash
 # This file is part of vim-hdl.
 #
+# Copyright (c) 2015-2016 Andre Souto
+#
 # vim-hdl is free software: you can redistribute it and/or modify
 # it under the terms of the GNU General Public License as published by
 # the Free Software Foundation, either version 3 of the License, or

--- a/syntax_checkers/systemverilog/vimhdl.vim
+++ b/syntax_checkers/systemverilog/vimhdl.vim
@@ -1,0 +1,76 @@
+" This file is part of vim-hdl.
+"
+" Copyright (c) 2015-2016 Andre Souto
+"
+" vim-hdl is free software: you can redistribute it and/or modify
+" it under the terms of the GNU General Public License as published by
+" the Free Software Foundation, either version 3 of the License, or
+" (at your option) any later version.
+"
+" vim-hdl is distributed in the hope that it will be useful,
+" but WITHOUT ANY WARRANTY; without even the implied warranty of
+" MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+" GNU General Public License for more details.
+"
+" You should have received a copy of the GNU General Public License
+" along with vim-hdl.  If not, see <http://www.gnu.org/licenses/>.
+"
+"============================================================================
+" For Syntastic license, check http://sam.zoy.org/wtfpl/COPYING
+"============================================================================
+
+" { Pre setup
+if exists("g:loaded_syntastic_systemverilog_vimhdl_checker")
+    finish
+endif
+let g:loaded_syntastic_systemverilog_vimhdl_checker = 1
+
+
+if !exists("g:syntastic_systemverilog_vimhdl_sort")
+    let g:syntastic_systemverilog_vimhdl_sort = 0 " vim-hdl returns sorted messages
+endif
+
+let s:save_cpo = &cpo
+set cpo&vim
+" }
+
+" { vimhdl availability checker
+function! SyntaxCheckers_systemverilog_vimhdl_IsAvailable() dict
+    if has('python')
+        return 1
+    endif
+    return 0
+endfunction
+
+" { vimhdl location list assembler
+function! SyntaxCheckers_systemverilog_vimhdl_GetLocList() dict
+    let loclist = []
+
+py <<EOF
+try:
+    loclist = vim.bindeval('loclist')
+except AttributeError:
+    loclist = vim.eval('loclist')
+try:
+    messages = vimhdl_client.getMessages(vim.current.buffer)
+except:
+    _logger.exception("Error getting messages")
+if messages:
+    loclist.extend(messages)
+EOF
+    return loclist
+
+endfunction
+" }
+
+" { Register vimhdl within Syntastic
+call g:SyntasticRegistry.CreateAndRegisterChecker({
+    \ 'exec'     : '',
+    \ 'filetype' : 'systemverilog',
+    \ 'name'     : 'vimhdl'})
+" }
+
+let &cpo = s:save_cpo
+unlet s:save_cpo
+
+" vim: set foldmarker={,} foldlevel=0 foldmethod=marker :

--- a/syntax_checkers/verilog/vimhdl.vim
+++ b/syntax_checkers/verilog/vimhdl.vim
@@ -1,0 +1,76 @@
+" This file is part of vim-hdl.
+"
+" Copyright (c) 2015-2016 Andre Souto
+"
+" vim-hdl is free software: you can redistribute it and/or modify
+" it under the terms of the GNU General Public License as published by
+" the Free Software Foundation, either version 3 of the License, or
+" (at your option) any later version.
+"
+" vim-hdl is distributed in the hope that it will be useful,
+" but WITHOUT ANY WARRANTY; without even the implied warranty of
+" MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+" GNU General Public License for more details.
+"
+" You should have received a copy of the GNU General Public License
+" along with vim-hdl.  If not, see <http://www.gnu.org/licenses/>.
+"
+"============================================================================
+" For Syntastic license, check http://sam.zoy.org/wtfpl/COPYING
+"============================================================================
+
+" { Pre setup
+if exists("g:loaded_syntastic_verilog_vimhdl_checker")
+    finish
+endif
+let g:loaded_syntastic_verilog_vimhdl_checker = 1
+
+
+if !exists("g:syntastic_verilog_vimhdl_sort")
+    let g:syntastic_verilog_vimhdl_sort = 0 " vim-hdl returns sorted messages
+endif
+
+let s:save_cpo = &cpo
+set cpo&vim
+" }
+
+" { vimhdl availability checker
+function! SyntaxCheckers_verilog_vimhdl_IsAvailable() dict
+    if has('python')
+        return 1
+    endif
+    return 0
+endfunction
+
+" { vimhdl location list assembler
+function! SyntaxCheckers_verilog_vimhdl_GetLocList() dict
+    let loclist = []
+
+py <<EOF
+try:
+    loclist = vim.bindeval('loclist')
+except AttributeError:
+    loclist = vim.eval('loclist')
+try:
+    messages = vimhdl_client.getMessages(vim.current.buffer)
+except:
+    _logger.exception("Error getting messages")
+if messages:
+    loclist.extend(messages)
+EOF
+    return loclist
+
+endfunction
+" }
+
+" { Register vimhdl within Syntastic
+call g:SyntasticRegistry.CreateAndRegisterChecker({
+    \ 'exec'     : '',
+    \ 'filetype' : 'verilog',
+    \ 'name'     : 'vimhdl'})
+" }
+
+let &cpo = s:save_cpo
+unlet s:save_cpo
+
+" vim: set foldmarker={,} foldlevel=0 foldmethod=marker :

--- a/syntax_checkers/vhdl/vimhdl.vim
+++ b/syntax_checkers/vhdl/vimhdl.vim
@@ -1,5 +1,7 @@
 " This file is part of vim-hdl.
 "
+" Copyright (c) 2015-2016 Andre Souto
+"
 " vim-hdl is free software: you can redistribute it and/or modify
 " it under the terms of the GNU General Public License as published by
 " the Free Software Foundation, either version 3 of the License, or


### PR DESCRIPTION
- Added `VimHdlRestartServer` command to restart server
- Only start `hdlcc` server when opening a supported file type
- Updating to the latest hdlcc
  - Filtering some useless XVHDL messages
  - Added basic Verilog/SystemVerilog support
  - Builder auto detection
  - Will compile files outside the project file (on a special library)
